### PR TITLE
Added quotation marks around titles of newsletters with colon chars

### DIFF
--- a/blog/_posts/2013-11-28-newsletter.md
+++ b/blog/_posts/2013-11-28-newsletter.md
@@ -1,5 +1,5 @@
 ---
-title: Labs newsletter: 28 November, 2013
+title: "Labs newsletter: 28 November, 2013"
 author: Neil Ashton
 username: nmashton
 layout: post

--- a/blog/_posts/2013-12-12-newsletter.md
+++ b/blog/_posts/2013-12-12-newsletter.md
@@ -1,5 +1,5 @@
 ---
-title: Labs newsletter: 12 December, 2013
+title: "Labs newsletter: 12 December, 2013"
 author: Neil Ashton
 username: nmashton
 layout: post

--- a/blog/_posts/2014-01-16-newsletter.md
+++ b/blog/_posts/2014-01-16-newsletter.md
@@ -1,5 +1,5 @@
 ---
-title: Labs newsletter: 16 January, 2014
+title: "Labs newsletter: 16 January, 2014"
 author: Neil Ashton
 username: nmashton
 layout: post

--- a/blog/_posts/2014-01-30-newsletter.md
+++ b/blog/_posts/2014-01-30-newsletter.md
@@ -1,5 +1,5 @@
 ---
-title: Labs newsletter: 30 January, 2014
+title: "Labs newsletter: 30 January, 2014"
 author: Neil Ashton
 username: nmashton
 layout: post

--- a/blog/_posts/2014-02-20-newsletter.md
+++ b/blog/_posts/2014-02-20-newsletter.md
@@ -1,5 +1,5 @@
 ---
-title: Labs newsletter: 20 February, 2014
+title: "Labs newsletter: 20 February, 2014"
 author: Neil Ashton
 username: nmashton
 layout: post
@@ -8,7 +8,7 @@ layout: post
 The past few weeks have seen major improvements to the Labs website, another Open Data Maker Night in London, updates to the TimeMapper project, and more.
 
 ## Labs Hangout: today
-  
+
 The next Labs online hangout is taking place today in just a few hours—now's your chance to sign up on [the hangout's Etherpad][1]!
 
 Labs hangouts are informal online gatherings held on Google Hangout at which Labs members and friends get together to discuss their work and to set the agenda for Labs activities.

--- a/blog/_posts/2014-03-20-newsletter.md
+++ b/blog/_posts/2014-03-20-newsletter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 author: Neil Ashton
-title: Labs newsletter: 20 March, 2013
+title: "Labs newsletter: 20 March, 2014"
 username: nmashton
 ---
 


### PR DESCRIPTION
Re-added the quotation marks around these titles as the colon character was confusing Jekyll.
