### PR TITLE
adding mozilla-csv-viewer  as a project  / an port of the great Rufus Pollock's chrome-csv-viewer

### DIFF
--- a/projects/_posts/2014-11-12-recline-mozilla-csv-viewer.html
+++ b/projects/_posts/2014-11-12-recline-mozilla-csv-viewer.html
@@ -1,0 +1,21 @@
+---
+layout: project
+title: Recline Mozilla CSV Viewer
+projecturl: https://github.com/okfn/mozilla-csv-viewer
+imageurl: https://lh4.googleusercontent.com/i1UJOeKmmBh6Od6clYYIkiNuEX5LJiyf927RDSjC3bgVo8YOynY6ZuGPEoNlHGYVL8R2tcqoRA=s640-h400-e365
+tags: [Javascript, FireFox Extension]
+author:
+maintainers: [alioune]
+github_user: aliounedia
+github_repo: mozilla-csv-viewer
+permalink: /projects/recline-mozilla-csv-viewer/index.html
+slug: recline-mozilla-csv-viewer
+language: [javascript, css]
+type: [tool]
+stage: mature
+---
+
+A FireFox extension which allows you to view, search, graph and map CSV files in the browser (built using Recline).
+This is an port of the great Rufus Pollock's chrome-csv-viewer on FireFox.
+
+


### PR DESCRIPTION
A FireFox extension which allows you to view, search, graph and map CSV files in the browser (built using Recline).This is an port of the great Rufus Pollock's chrome-csv-viewer on FireFox.
