### PR TITLE
Fix old 'previous event' links

### DIFF
--- a/events/open-data-maker/index.md
+++ b/events/open-data-maker/index.md
@@ -103,7 +103,7 @@ If you want some suggestions or help just [get in touch](/contact/).
 
 ## Previous Events
 
-* [London No. 3 - Tuesday 16th July](http://okfnlabs.org/blog/2013/07/08/open-data-maker-night-london-3.html)
-* [Birmingham, UK - Thursday 25th April](http://www.meetup.com/OpenKnowledgeFoundation/Birmingham-GB/907622/)
-* [Vienna No. 1 - Thursday 18th April](http://www.meetup.com/OpenKnowledgeFoundation/Austria/928052/)
-* [London No. 1 - Tuesday 16th March](http://blog.okfn.org/2013/03/13/open-data-maker-night/) - this was the inaugural event
+* [London No. 3 - Tuesday 16th July 2013](http://okfnlabs.org/blog/events/2013/07/08/open-data-maker-night-london-3.html)
+* Birmingham, UK - Thursday 25th April 2013
+* Vienna No. 1 - Thursday 18th April 2013
+* [London No. 1 - Tuesday 16th March 2013](http://blog.okfn.org/2013/03/13/open-data-maker-night/) - this was the inaugural event


### PR DESCRIPTION
Links here are obviously very old. Various fixes
- 1st one was broken. found where it's moved to
- 2nd and 3rd ones points at a meet-up group which no longer exists
- All of them need to be labelled as 2013
guess there was a lull in 2014?