### PR TITLE
Labs sysadmin info

### DIFF
--- a/_data/machines.yml
+++ b/_data/machines.yml
@@ -1,0 +1,8 @@
+- name: "machine1"
+  services:
+    - "some service"
+- name: "machine2"
+  services:
+    - "service!"
+    - "yet another service"
+    - "probably too many services on this one"

--- a/about/sysadmin/data.json
+++ b/about/sysadmin/data.json
@@ -1,0 +1,17 @@
+---
+---
+
+{
+  "sysadmins":
+  { {% for person in site.categories.members %}{% if person.roles contains "sysadmin" %}
+    "{{ person.username }}":
+    {
+      "name": "{{ person.title }}",
+      "key": "{{ person.publickey }}"
+    } {% if forloop.last != true %},{% endif %}{% endif %}{% endfor %}
+  },
+  "services":
+  { {% for machine in site.data.machines %}{% for service in machine.services %}
+    "{{ service }}": "{{ machine.name }}"{% if forloop.last != true %},{% endif %}{% endfor %}{% if forloop.last != true %},{% endif %}{% endfor %}
+  }
+}

--- a/members/_posts/2005-01-01-rgrp.html
+++ b/members/_posts/2005-01-01-rgrp.html
@@ -11,6 +11,7 @@ place: London, UK
 contributor: true
 permalink: /members/rgrp/index.html
 roles: [lead,sysadmin,ran-open-data-maker]
+publickey: "ssh-dss AAAAB3NzaC1kc3MAAACBAN3MM1dL+9IqSU7fP14IxvZI2bS0whPz6LOTBEgLIW+KqtS8koIC3BU1cymo2nF1mbMM1d7xSh09RbHR8feT9W85pn4slMjUC8yMoeaODku038mMSqK2j6vhFm/DLUEqNIYpn34ZdykvO8hyVmoy7lJqcAjiGbP7WfQjwMYFHOZpAAAAFQCwcdhE6xj3p+W5P1l5ZrmPFq0LKwAAAIEA0khO9JR4QHchzHDUTueyoWXEfH14iHU9nHCRoJZViV1I6mTMSgPqAWx+RYIWN/peuyWxTvgJTRl6B+NetMi35nkY+uVNe4PfFVsGqWzXRySsQUKg2OpWc465nHlJTB7lz6GQoo5zBKP55gki8PJpbjLL4LhnmTCirl7BTTfCtfYAAACAWXZOAqKhudB7TcZQU9AJK3zVtjYtCm/eTVrXQwvXMtnU3SP8LioJtXKDpw9xRhcSekvvA6o03HJ2KnNf4robXbb8eb++6yuXH3FcSUlK5lZeDtFVrbN3nbppcZzWRSNGwavPsTMfQDANcbuTmEAsb+2wwHmuqyITpwciG3iIyCs= rgrp@gimmel"
 ---
 
 Rufus is an avid hacker on many small data tools, an enthusiastic collector of

--- a/members/_posts/2014-03-13-mikechelen.md
+++ b/members/_posts/2014-03-13-mikechelen.md
@@ -10,6 +10,8 @@ web: http://michaelchelen.net/
 img: https://pbs.twimg.com/profile_images/2302383029/k73pveeaaj2zxbkf3chq_bigger.jpeg
 place: Washington DC, USA
 permalink: /members/mikechelen/index.html
+roles: [sysadmin]
+publickey: "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA0PSUWKd4z2g4hNvRKJ3xfpFTdq8/Qq0KnHYnoC3ZBvJ812WqVDd0FgOYFqAgaOUQJFiZRiMfRiIjqHm4dY+pjzsN7zsWZiYgcglHYfugnQ086rKKKwruzQrKggED5hXO4f2ekRLU37ajh3Oku9eqSiNwiBNuywlTfv6C25HzEG5BWmwstZ7D77RSdwJtOaGe+aUFg1s7qhF+tIggwtZKnFtiY35kKjECi5BCl7seSvC2qUsQ2HYvmnpkeh3P5OQT5sxLihxodvwcnsx5X60afUo8AMAa7zUahbsyMK/HhnCpQf1zsXYR/gZbvjq9ZI/wk4GaeqslE653z7dkzjACPQ== @mikechelen"
 contributor: true
 ---
 

--- a/members/_posts/2014-11-15-dfowler.md
+++ b/members/_posts/2014-11-15-dfowler.md
@@ -10,6 +10,8 @@ web: http://www.danfowler.net
 img: https://s.gravatar.com/avatar/fca5da31aa7e04a908c340fb42513009?s=120
 place: Addis Ababa, Ethiopia
 permalink: /members/dfowler/index.html
+roles: [sysadmin]
+publickey: "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA2CCGyRlyVQmpZmeejeioC+WJIVk37CDhTRCbQLbFZUnR85TAs1F6/wOtN43B9yH/yRtEGszxwiukXQbqSE3ROXgYedpVj3ARMj1iQibN2x6l7GpkFvnJq/7GjwBvie3YZgNIRAeVK57/pk1+CPWSMy96jRD747ZFh7kpbxX6og8wmlf7ts8IW6pvbdyvxs+ybFCgrU4i2+p9WZd6W1AgOJJrKqXQ6V0IYUW49f4e5JoVOqEVgrRMNI4XPB8pUkLmgxZNM9vXc1tvyTbzb5TB1G8vzCn84SVBve296GI6uEftLZ8k27f6yrSF8P280cnptFeBrny1UZMRobInBIFhEw== @danfowler"
 ---
 
 Dan recently completed an [MSc in ICT for


### PR DESCRIPTION
Attempt at #223. SSH keys pulled from https://github.com/okfn/infra/blob/16fee4cd0b9e0723d24418d5bccf82ed1f649692/ssh_keys.js

Sysadmin info is stored as a property on a user.  Service/machine info is stored in _data directory.  Both are compiled into a data.json file within /about/sysadmin/