### PR TITLE
add data wrangling guest post - datapak gem - working with tabular data packages w/ ruby and sqlite

### DIFF
--- a/blog/_posts/2015-04-26-datapak.md
+++ b/blog/_posts/2015-04-26-datapak.md
@@ -1,0 +1,332 @@
+---
+layout: post
+author: Gerald Bauer
+username: geraldb
+title: "datapak gem - Work with Tabular Data Packages using Ruby and SQLite"
+projects: [frictionless-data]
+---
+
+Let's say you want to share your data with the world
+or use the data that others share with the world. How to get started?
+A pragmatic way is to use tabular data packages.
+
+## What's a tabular data package?
+
+> Tabular Data Package is a simple structure for publishing and sharing
+> tabular data with the following key features:
+>
+> - Data is stored in CSV (comma separated values) files
+> - Metadata about the dataset both general (e.g. title, author)
+>   and the specific data files (e.g. schema) is stored in a single JSON file
+>   named `datapackage.json` which follows the Data Package format
+
+(Source: [Tabular Data Packages, Open Knowledge Foundation](http://data.okfn.org/doc/tabular-data-package))
+
+Here's a minimal example of a tabular data package
+holding two files, that is, `data.csv` and `datapackage.json`:
+ 
+`data.csv`:
+
+~~~~
+Date,Team 1,Team 2,FT,HT
+2013-08-17,Arsenal,Aston Villa,1-3,1-1
+2013-08-17,Liverpool,Stoke,1-0,1-0
+2013-08-17,Norwich,Everton,2-2,0-0
+2013-08-17,Sunderland,Fulham,0-1,0-0
+2013-08-17,Swansea,Man United,1-4,0-2
+2013-08-17,West Brom,Southampton,0-1,0-0
+2013-08-17,West Ham,Cardiff,2-0,1-0
+2013-08-18,Chelsea,Hull,2-0,2-0
+2013-08-18,Crystal Palace,Tottenham,0-1,0-0
+2013-08-19,Man City,Newcastle,4-0,2-0
+...
+~~~~
+
+`datapackage.json`:
+
+~~~~
+{
+  "name": "football-england",
+  "resources": [
+    {
+      "path": "1-premierleague.csv",
+      "schema": {
+        "fields": [ { "name": "Date",      "type": "date" },
+                    { "name": "Team 1",    "type": "string" },
+                    { "name": "Team 2",    "type": "string" },
+                    { "name": "FT",        "type": "string" },
+                    { "name": "HT",        "type": "string" } ]
+      }
+    }
+  ]
+}
+~~~~
+
+### Where to find data packages?
+
+For some more examples see the [Data Packages Listing](http://data.okfn.org/data) at
+the - surprise, surprise - Open Knowledge Foundation (OKFN) site for a start.
+Tabular data packages include:
+
+Name                     | Comments
+------------------------ | -------------
+`country-codes`          | Comprehensive country codes: ISO 3166, ITU, ISO 4217 currency codes and many more
+`language-codes`         | ISO Language Codes (639-1 and 693-2)
+`currency-codes`         | ISO 4217 Currency Codes
+`gdb`                    | Country, Regional and World GDP (Gross Domestic Product)
+`s-and-p-500-companies`  | S&P 500 Companies with Financial Information
+`un-locode`              | UN-LOCODE Codelist
+
+and many more.
+
+
+## What's the datapak gem?
+
+Now the questions is how to work with tabular data packages in Ruby.
+Let's try the datapak gem.
+
+~~~
+require 'datapak`
+
+Datapak.import(
+  's-and-p-500-companies',
+  'gdb'
+)
+~~~
+
+Using `Datapak.import` will:
+
+1) download all data packages to the `./pak` folder
+
+2) (auto-)add all tables to an in-memory SQLite database using SQL `create_table`
+   commands via `ActiveRecord` migrations e.g.
+
+~~~
+create_table :constituents_financials do |t|
+  t.string :symbol             # Symbol         (string)
+  t.string :name               # Name           (string)
+  t.string :sector             # Sector         (string)
+  t.float  :price              # Price          (number)
+  t.float  :dividend_yield     # Dividend Yield (number)
+  t.float  :price_earnings     # Price/Earnings (number)
+  t.float  :earnings_share     # Earnings/Share (number)
+  t.float  :book_value         # Book Value     (number)
+  t.float  :_52_week_low       # 52 week low    (number)
+  t.float  :_52_week_high      # 52 week high   (number)
+  t.float  :market_cap         # Market Cap     (number)
+  t.float  :ebitda             # EBITDA         (number)
+  t.float  :price_sales        # Price/Sales    (number)
+  t.float  :price_book         # Price/Book     (number)
+  t.string :sec_filings        # SEC Filings    (string)
+end
+~~~
+
+3) (auto-)import all records using SQL inserts e.g.
+
+~~~
+INSERT INTO constituents_financials
+  (symbol,
+   name,
+   sector,
+   price,
+   dividend_yield,
+   price_earnings,
+   earnings_share,
+   book_value,
+   _52_week_low,
+   _52_week_high,
+   market_cap,
+   ebitda,
+   price_sales,
+   price_book,
+   sec_filings)
+VALUES
+  ('MMM',
+   '3M Co',
+   'Industrials',
+   162.27,
+   2.11,
+   22.28,
+   7.284,
+   25.238,
+   123.61,
+   162.92,
+   104.0,
+   8.467,
+   3.28,
+   6.43,
+   'http://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK=MMM')
+~~~
+
+4) (auto-)add `ActiveRecord` models for all tables.
+
+
+So what? Now you can use all the "magic" of `ActiveRecord` to work
+with the datasets. Example:
+
+~~~
+puts "Constituent.count: #{Constituent.count}"
+
+# SELECT COUNT(*) FROM "constituents"
+# => 496
+
+
+pp Constituent.first
+
+# SELECT  "constituents".* FROM "constituents" ORDER BY "constituents"."id" ASC LIMIT 1
+# => #<Constituent:0x9f8cb78
+         id:     1,
+         symbol: "MMM",
+         name:   "3M Co",
+         sector: "Industrials">
+
+
+pp Constituent.find_by!( symbol: 'MMM' )
+
+# SELECT  "constituents".*
+         FROM "constituents"
+         WHERE "constituents"."symbol" = "MMM"
+         LIMIT 1
+# => #<Constituent:0x9f8cb78
+         id:     1,
+         symbol: "MMM",
+         name:   "3M Co",
+         sector: "Industrials">
+
+
+pp Constituent.find_by!( name: '3M Co' )
+
+# SELECT  "constituents".*
+          FROM "constituents"
+          WHERE "constituents"."name" = "3M Co"
+          LIMIT 1
+# => #<Constituent:0x9f8cb78
+         id:     1,
+         symbol: "MMM",
+         name:   "3M Co",
+         sector: "Industrials">
+
+
+pp Constituent.where( sector: 'Industrials' ).count
+
+# SELECT COUNT(*) FROM "constituents"
+         WHERE "constituents"."sector" = "Industrials"
+# => 63
+
+
+pp Constituent.where( sector: 'Industrials' ).all
+
+# SELECT "constituents".*
+         FROM "constituents"
+         WHERE "constituents"."sector" = "Industrials"
+# => [#<Constituent:0x9f8cb78
+          id:     1,
+          symbol: "MMM",
+          name:   "3M Co",
+          sector: "Industrials">,
+      #<Constituent:0xa2a4180
+          id:     8,
+          symbol: "ADT",
+          name:   "ADT Corp (The)",
+          sector: "Industrials">,...]
+
+and so on
+~~~
+
+
+### How to dowload a data package ("by hand")?
+
+Use the `Datapak::Downloader` class to download a data package
+to your disk (by default data packages get stored in `./pak`).
+
+~~~
+dl = Datapak::Downloader.new
+dl.fetch( 'language-codes' )
+dl.fetch( 's-and-p-500-companies' )
+dl.fetch( 'un-locode`)
+~~~
+
+Will result in:
+
+~~~
+-- pak
+   |-- language-codes
+   |   |-- data
+   |   |   |-- language-codes-3b2.csv
+   |   |   |-- language-codes.csv
+   |   |   `-- language-codes-full.csv
+   |   `-- datapackage.json
+   |-- s-and-p-500-companies
+   |   |-- data
+   |   |   |-- constituents.csv
+   |   |   `-- constituents-financials.csv
+   |   `-- datapackage.json
+   `-- un-locode
+       |-- data
+       |   |-- code-list.csv
+       |   |-- country-codes.csv
+       |   |-- function-classifiers.csv
+       |   |-- status-indicators.csv
+       |   `-- subdivision-codes.csv
+       `-- datapackage.json
+~~~
+
+### How to add and import a data package ("by hand")?
+
+Use the `Datapak::Pak` class to read-in a data package
+and add and import into an SQL database. 
+
+~~~
+pak = Datapak::Pak.new( './pak/un-locode/datapackage.json' )
+pak.tables.each do |table|
+  table.up!      # (auto-) add table  using SQL create_table via ActiveRecord migration
+  table.import!  # import all records using SQL inserts
+end
+~~~
+
+That's it.
+
+
+## Bonus: How to connect to a different SQL database?
+
+You can connect to any database supported by ActiveRecord. If you do NOT
+establish a connection in your script - the standard (default fallback)
+is using an in-memory SQLite3 database.
+
+### SQLite
+
+For example, to create an SQLite3 database on disk - lets say `datapak.db` -
+use in your script (before the `Datapak.import` statement):
+
+~~~
+ActiveRecord::Base.establish_connection( adapter:  'sqlite3
+                                         database: './datapak.db' )
+~~~
+
+### PostgreSQL 
+
+For example, to connect to a PostgreSQL database use in your script
+(before the `Datapak.import` statement):
+
+~~~
+require 'pg'       ##  pull-in PostgreSQL (pg) machinery
+
+ActiveRecord::Base.establish_connection( adapter:  'postgresql'
+                                         username: 'ruby'",
+                                         password: 'topsecret',
+                                         database: 'database' )
+~~~
+
+
+##  Find Out More 
+
+datapak
+
+* home     :: [github.com/textkit/datapak](https://github.com/textkit/datapak)
+* gem      :: [rubygems.org/gems/datapak](https://rubygems.org/gems/datapak)
+* rdoc     :: [rubydoc.info/gems/datapak](http://rubydoc.info/gems/datapak)
+
+Tabular Data Package
+
+* spec     :: [dataprotocols.org/tabular-data-package](http://dataprotocols.org/tabular-data-package)
+* datasets :: [data.okfn.org/data](http://data.okfn.org/data)

--- a/members/_posts/2015-04-28-geraldb.html
+++ b/members/_posts/2015-04-28-geraldb.html
@@ -1,0 +1,14 @@
+---
+layout: person
+username: geraldb
+title: Gerald Bauer
+area: Data Wrangler, Beer Hunter, Football Statistican
+email: gerald.bauer@gmail.com
+github: geraldb
+place: Vienna, Austria 
+permalink: /members/geraldb/index.html
+---
+
+Gerald is an internet professional with more than 10+ years of industry experience
+(has worked for Google, Apple, and others) and an enthusiastic collector of
+football and beer data. Skills include Ruby, SQLite and COBOL.


### PR DESCRIPTION
Hello,
   Thanks for the great tabular data package format. I've coded and published a little library in Ruby that lets you work with tabular data packages with Ruby ActiceRecord models (ORM wrapper) and, thus, your SQL database of choice (by default the library will use an in-memory SQLite database). It would be great to get the post about the datapak gem (library) posted on the Data Wrangling Blog. Feel free to change or edit as needed. Cheers.
PS: I'm the author of a previous guest post (last year in 2014) about the football.db and open data for the World Cup in Brazil.