### PR TITLE
Adds link to forum in primary navigation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,7 +58,7 @@
         <ul class="nav pull-right">
           <li><a class="nav-join" href="/join">Join</a></li>
           <li><a class="nav-blog" href="/blog">Blog</a></li>
-          <li><a class="nav-forum" href="https://discuss.okfn.org/">Forum</a></li>
+          <li><a class="nav-forum" href="https://discuss.okfn.org/c/open-knowledge-labs">Forum</a></li>
           <li><a class="nav-code" href="/projects/#featured=true">Projects</a></li>
           <li><a class="nav-events" href="/events">Events</a></li>
           <li><a class="nav-about" href="/about">About</a></li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,6 +58,7 @@
         <ul class="nav pull-right">
           <li><a class="nav-join" href="/join">Join</a></li>
           <li><a class="nav-blog" href="/blog">Blog</a></li>
+          <li><a class="nav-forum" href="https://discuss.okfn.org/">Forum</a></li>
           <li><a class="nav-code" href="/projects/#featured=true">Projects</a></li>
           <li><a class="nav-events" href="/events">Events</a></li>
           <li><a class="nav-about" href="/about">About</a></li>

--- a/css/labs.css
+++ b/css/labs.css
@@ -292,6 +292,7 @@ body {
 }
 .body-join .navbar .nav-join,
 .body-blog .nav-blog,
+.body-forum .nav-forum,
 .body-data .nav-data,
 .body-code .nav-code,
 .body-events .nav-events,


### PR DESCRIPTION
This relates to [this issue] (https://github.com/okfn/okfn.github.com/issues/396)

@danfowler this commit adds a link to the forum at the top of the page. Obviously, please ignore this if you wish to add a link elsewhere :)