### PR TITLE
Closing old newsletter-based issues, added howto search for newsletter-related issues on newsletter/index.md

### DIFF
--- a/newsletter/index.md
+++ b/newsletter/index.md
@@ -21,4 +21,8 @@ A good submission will help us get the newsletter organized efficiently, and wou
 
 You'll be updated as to the inclusion of the submission in the newsletter via the same issue.
 
+## Viewing items submitted to the newsletter
+
+All items submitted to the newsletter are stored as issues within the okfn/okfn.github.com repo. To view all of the submissions, simply navigate to the issues tab of the okfn/okfn.github.com repo and then search for "is:issue is:open newsletter" (without the quotes). Or, you can just follow [this link](https://github.com/okfn/okfn.github.com/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+newsletter) instead!
+
 <a class="btn btn-primary" href="https://github.com/okfn/okfn.github.com/issues/new?title=[newsletter]">Submit an Item</a>


### PR DESCRIPTION
This closes #395, closes #391, closes #382, closes #381, closes #379, closes #377, and closes #374. (Per @dfowler's request in 395#issuecomment-165107721). Couldnt figure out howto close issues without committing something, so I added a howoto tip on searching for newsletter-related issues to newsletter/index.md. In the future I plan to simply close old newsletter issues when I commit the latest issue so this should be a one-time thing