### PR TITLE
Issue #274, adding status to each project

### DIFF
--- a/projects/_posts/1970-02-01-offenesparlement.html
+++ b/projects/_posts/1970-02-01-offenesparlement.html
@@ -12,7 +12,7 @@ slug: offenesparlament
 language: [javascript, python, css]
 type: [webapp, running service, tool]
 stage: live
-status: -STATUS-
+status: [active]
 ---
 
 OffenesParlement is a site (and open-source codebase) for gathering and presenting information about the work of the Bundestag and Bundesrat.

--- a/projects/_posts/1970-02-01-offenesparlement.html
+++ b/projects/_posts/1970-02-01-offenesparlement.html
@@ -12,6 +12,7 @@ slug: offenesparlament
 language: [javascript, python, css]
 type: [webapp, running service, tool]
 stage: live
+status: -STATUS-
 ---
 
 OffenesParlement is a site (and open-source codebase) for gathering and presenting information about the work of the Bundestag and Bundesrat.

--- a/projects/_posts/1970-02-14-fyi-org-nz.html
+++ b/projects/_posts/1970-02-14-fyi-org-nz.html
@@ -15,7 +15,7 @@ typeofhelp: []
 language: [ruby, css, javascript, shell]
 type: [webapp, running service, tool]
 stage: live
-status: -STATUS-
+status: [active]
 ---
 
 Make Official Information Act requests in New Zealand

--- a/projects/_posts/1970-02-14-fyi-org-nz.html
+++ b/projects/_posts/1970-02-14-fyi-org-nz.html
@@ -15,6 +15,7 @@ typeofhelp: []
 language: [ruby, css, javascript, shell]
 type: [webapp, running service, tool]
 stage: live
+status: -STATUS-
 ---
 
 Make Official Information Act requests in New Zealand

--- a/projects/_posts/1970-03-01-wikipediajs.html
+++ b/projects/_posts/1970-03-01-wikipediajs.html
@@ -12,7 +12,7 @@ slug: wikipediajs
 language: [javascript, css]
 type: [library, webapp, running service]
 stage: prototype
-status: -STATUS-
+status: [active]
 ---
 
 WikipediaJS is a simple JS library for accessing information in Wikipedia articles such as dates, places, abstracts etc.

--- a/projects/_posts/1970-03-01-wikipediajs.html
+++ b/projects/_posts/1970-03-01-wikipediajs.html
@@ -12,6 +12,7 @@ slug: wikipediajs
 language: [javascript, css]
 type: [library, webapp, running service]
 stage: prototype
+status: -STATUS-
 ---
 
 WikipediaJS is a simple JS library for accessing information in Wikipedia articles such as dates, places, abstracts etc.

--- a/projects/_posts/1970-04-01-data-converters.html
+++ b/projects/_posts/1970-04-01-data-converters.html
@@ -12,7 +12,7 @@ slug: data-converters
 language: [python]
 type: [library, tool]
 stage: prototype
-status: -STATUS-
+status: [active]
 ---
 
 Python library and command line tool for converting data from one format to another. It builds on messytables, GDAL and many more great open-source libraries for processing data, and provides one easy to use standard API.

--- a/projects/_posts/1970-04-01-data-converters.html
+++ b/projects/_posts/1970-04-01-data-converters.html
@@ -12,6 +12,7 @@ slug: data-converters
 language: [python]
 type: [library, tool]
 stage: prototype
+status: -STATUS-
 ---
 
 Python library and command line tool for converting data from one format to another. It builds on messytables, GDAL and many more great open-source libraries for processing data, and provides one easy to use standard API.

--- a/projects/_posts/1970-05-01-messytables.html
+++ b/projects/_posts/1970-05-01-messytables.html
@@ -13,6 +13,7 @@ language: [python]
 type: [library, tool]
 stage: prototype
 
+status: -STATUS-
 ---
 
 Tools for parsing messy tabular data.

--- a/projects/_posts/1970-05-01-messytables.html
+++ b/projects/_posts/1970-05-01-messytables.html
@@ -12,8 +12,7 @@ slug: messytables
 language: [python]
 type: [library, tool]
 stage: prototype
-
-status: -STATUS-
+status: [active]
 ---
 
 Tools for parsing messy tabular data.

--- a/projects/_posts/1970-06-01-kartograph.html
+++ b/projects/_posts/1970-06-01-kartograph.html
@@ -12,6 +12,7 @@ slug: kartograph
 language: [javascript, coffeescript, css, shell]
 type: [library]
 stage: graduated
+status: -STATUS-
 ---
 
 Kartograph is a simple and lightweight framework for building interactive map applications without Google Maps or any other mapping service. It was created with the needs of designers and data journalists in mind.

--- a/projects/_posts/1970-06-01-kartograph.html
+++ b/projects/_posts/1970-06-01-kartograph.html
@@ -12,7 +12,7 @@ slug: kartograph
 language: [javascript, coffeescript, css, shell]
 type: [library]
 stage: graduated
-status: -STATUS-
+status: [active]
 ---
 
 Kartograph is a simple and lightweight framework for building interactive map applications without Google Maps or any other mapping service. It was created with the needs of designers and data journalists in mind.

--- a/projects/_posts/1970-07-01-recline-chrome-csv-viewer.html
+++ b/projects/_posts/1970-07-01-recline-chrome-csv-viewer.html
@@ -13,7 +13,7 @@ slug: recline-chrome-csv-viewer
 language: [javascript, css]
 type: [tool]
 stage: mature
-status: -STATUS-
+status: [active]
 ---
 
 A chrome extension which allows you to view, search, graph and map CSV files in the browser (built using Recline)

--- a/projects/_posts/1970-07-01-recline-chrome-csv-viewer.html
+++ b/projects/_posts/1970-07-01-recline-chrome-csv-viewer.html
@@ -13,6 +13,7 @@ slug: recline-chrome-csv-viewer
 language: [javascript, css]
 type: [tool]
 stage: mature
+status: -STATUS-
 ---
 
 A chrome extension which allows you to view, search, graph and map CSV files in the browser (built using Recline)

--- a/projects/_posts/1970-08-01-bundesgit.html
+++ b/projects/_posts/1970-08-01-bundesgit.html
@@ -16,5 +16,5 @@ typeofhelp: []
 language: [markdown]
 type: [data]
 stage: live
-status: -STATUS-
+status: [active]
 ---

--- a/projects/_posts/1970-08-01-bundesgit.html
+++ b/projects/_posts/1970-08-01-bundesgit.html
@@ -16,4 +16,5 @@ typeofhelp: []
 language: [markdown]
 type: [data]
 stage: live
+status: -STATUS-
 ---

--- a/projects/_posts/1970-09-01-timemapper.html
+++ b/projects/_posts/1970-09-01-timemapper.html
@@ -13,6 +13,7 @@ helpwanted: yes
 language: [javascript, css]
 type: [webapp, running service, tool]
 stage: live
+status: -STATUS-
 ---
 
 Make timelines & maps from a Google Spreadsheet in seconds

--- a/projects/_posts/1970-09-01-timemapper.html
+++ b/projects/_posts/1970-09-01-timemapper.html
@@ -13,7 +13,7 @@ helpwanted: yes
 language: [javascript, css]
 type: [webapp, running service, tool]
 stage: live
-status: -STATUS-
+status: [active]
 ---
 
 Make timelines & maps from a Google Spreadsheet in seconds

--- a/projects/_posts/1970-10-01-listify.html
+++ b/projects/_posts/1970-10-01-listify.html
@@ -14,6 +14,7 @@ slug: listify
 language: [javascript, css]
 type: [webapp, running service, tool]
 stage: live
+status: -STATUS-
 ---
 
 Turn a Google spreadsheet into a beautiful, searchable listing in seconds

--- a/projects/_posts/1970-10-01-listify.html
+++ b/projects/_posts/1970-10-01-listify.html
@@ -14,7 +14,7 @@ slug: listify
 language: [javascript, css]
 type: [webapp, running service, tool]
 stage: live
-status: -STATUS-
+status: [active]
 ---
 
 Turn a Google spreadsheet into a beautiful, searchable listing in seconds

--- a/projects/_posts/1970-11-01-iati-tools.html
+++ b/projects/_posts/1970-11-01-iati-tools.html
@@ -12,7 +12,7 @@ slug: iati-tools
 language: [python, javascript]
 type: [library, tool]
 stage: mature
-status: -STATUS-
+status: [active]
 ---
 
 Library for working with IATI data and converting it into a relational database. http://blog.okfn.org/2012/06/05/from-xml-to-visualisations-iati/

--- a/projects/_posts/1970-11-01-iati-tools.html
+++ b/projects/_posts/1970-11-01-iati-tools.html
@@ -12,6 +12,7 @@ slug: iati-tools
 language: [python, javascript]
 type: [library, tool]
 stage: mature
+status: -STATUS-
 ---
 
 Library for working with IATI data and converting it into a relational database. http://blog.okfn.org/2012/06/05/from-xml-to-visualisations-iati/

--- a/projects/_posts/1970-12-01-textus.html
+++ b/projects/_posts/1970-12-01-textus.html
@@ -14,7 +14,7 @@ slug: textus
 language: [javascript, css]
 type: [webapp, running service, tool]
 stage: live
-status: -STATUS-
+status: [active]
 ---
 
 In a nutshell it is an open source platform for working with collections of texts. It enables students, researchers and teachers to share and collaborate around texts using a simple and intuitive interface.

--- a/projects/_posts/1970-12-01-textus.html
+++ b/projects/_posts/1970-12-01-textus.html
@@ -14,6 +14,7 @@ slug: textus
 language: [javascript, css]
 type: [webapp, running service, tool]
 stage: live
+status: -STATUS-
 ---
 
 In a nutshell it is an open source platform for working with collections of texts. It enables students, researchers and teachers to share and collaborate around texts using a simple and intuitive interface.

--- a/projects/_posts/1971-01-01-retrato-da-violencia.html
+++ b/projects/_posts/1971-01-01-retrato-da-violencia.html
@@ -12,6 +12,7 @@ slug: retrato-da-violencia
 language: [ruby, javascript, perl, css]
 type: [data, tool]
 stage: prototype
+status: -STATUS-
 ---
 
 Visualization on violence against women in the brazilian state Rio Grande do Sul.

--- a/projects/_posts/1971-01-01-retrato-da-violencia.html
+++ b/projects/_posts/1971-01-01-retrato-da-violencia.html
@@ -12,7 +12,7 @@ slug: retrato-da-violencia
 language: [ruby, javascript, perl, css]
 type: [data, tool]
 stage: prototype
-status: -STATUS-
+status: [active]
 ---
 
 Visualization on violence against women in the brazilian state Rio Grande do Sul.

--- a/projects/_posts/1971-02-01-annotator.html
+++ b/projects/_posts/1971-02-01-annotator.html
@@ -13,7 +13,7 @@ slug: annotator
 language: [javascript, css]
 type: [library]
 stage: graduated
-status: -STATUS-
+status: [active]
 ---
 
 The Annotator is an open-source JavaScript library and tool that can be added to any webpage to make it annotatable.

--- a/projects/_posts/1971-02-01-annotator.html
+++ b/projects/_posts/1971-02-01-annotator.html
@@ -13,6 +13,7 @@ slug: annotator
 language: [javascript, css]
 type: [library]
 stage: graduated
+status: -STATUS-
 ---
 
 The Annotator is an open-source JavaScript library and tool that can be added to any webpage to make it annotatable.

--- a/projects/_posts/1971-03-01-frag-den-staat.html
+++ b/projects/_posts/1971-03-01-frag-den-staat.html
@@ -13,6 +13,7 @@ slug: frag-den-staat
 language: [python, javascript, css]
 type: [webapp, running service]
 stage: live
+status: -STATUS-
 ---
 
 Germany Freedom of Information portal powered by the <a

--- a/projects/_posts/1971-03-01-frag-den-staat.html
+++ b/projects/_posts/1971-03-01-frag-den-staat.html
@@ -13,7 +13,7 @@ slug: frag-den-staat
 language: [python, javascript, css]
 type: [webapp, running service]
 stage: live
-status: -STATUS-
+status: [active]
 ---
 
 Germany Freedom of Information portal powered by the <a

--- a/projects/_posts/1971-03-02-froide.html
+++ b/projects/_posts/1971-03-02-froide.html
@@ -14,7 +14,7 @@ language: [python]
 type: [webapp]
 stage: live
 featured: true
-status: -STATUS-
+status: [active]
 ---
 
 <p>Froide is a Freedom of Information portal written in Python using the Django

--- a/projects/_posts/1971-03-02-froide.html
+++ b/projects/_posts/1971-03-02-froide.html
@@ -14,6 +14,7 @@ language: [python]
 type: [webapp]
 stage: live
 featured: true
+status: -STATUS-
 ---
 
 <p>Froide is a Freedom of Information portal written in Python using the Django

--- a/projects/_posts/1971-04-01-crowdcrafting-and-pybossa.html
+++ b/projects/_posts/1971-04-01-crowdcrafting-and-pybossa.html
@@ -15,6 +15,7 @@ slug: crowdcrafting-and-pybossa
 language: [python, javascript, css, html]
 type: [webapp, running service, tool]
 stage: graduated
+status: -STATUS-
 ---
 
 CrowdCrafting is a free, open-source crowd-sourcing and micro-tasking platform powered by the <a href="http://dev.pybossa.com">PyBossa</a> software. This platform enables people to <strong>create and run projects that utilize on-line assistance in performing tasks that require human cognition</strong> such as <em>image classification, transcription, geocoding and more</em>. CrowdCrafting is there to help researchers, civic hackers and developers to create projects where anyone around the world with some time, interest and an Internet connection can contribute.

--- a/projects/_posts/1971-04-01-crowdcrafting-and-pybossa.html
+++ b/projects/_posts/1971-04-01-crowdcrafting-and-pybossa.html
@@ -15,7 +15,7 @@ slug: crowdcrafting-and-pybossa
 language: [python, javascript, css, html]
 type: [webapp, running service, tool]
 stage: graduated
-status: -STATUS-
+status: [active]
 ---
 
 CrowdCrafting is a free, open-source crowd-sourcing and micro-tasking platform powered by the <a href="http://dev.pybossa.com">PyBossa</a> software. This platform enables people to <strong>create and run projects that utilize on-line assistance in performing tasks that require human cognition</strong> such as <em>image classification, transcription, geocoding and more</em>. CrowdCrafting is there to help researchers, civic hackers and developers to create projects where anyone around the world with some time, interest and an Internet connection can contribute.

--- a/projects/_posts/1971-05-01-nomenklatura.html
+++ b/projects/_posts/1971-05-01-nomenklatura.html
@@ -15,6 +15,7 @@ slug: nomenklatura
 language: [python, javascript, css, shell]
 type: [webapp, running service, tool]
 stage: live
+status: -STATUS-
 ---
 Nomenklatura de-duplicates and integrates different names for entities - people, organisations or public bodies - to help you clean up messy data and to find links between different datasets.
 

--- a/projects/_posts/1971-05-01-nomenklatura.html
+++ b/projects/_posts/1971-05-01-nomenklatura.html
@@ -15,7 +15,7 @@ slug: nomenklatura
 language: [python, javascript, css, shell]
 type: [webapp, running service, tool]
 stage: live
-status: -STATUS-
+status: [active]
 ---
 Nomenklatura de-duplicates and integrates different names for entities - people, organisations or public bodies - to help you clean up messy data and to find links between different datasets.
 

--- a/projects/_posts/1971-06-01-bubble-tree-library.html
+++ b/projects/_posts/1971-06-01-bubble-tree-library.html
@@ -12,7 +12,7 @@ slug: bubble-tree-library
 language: [javascript, coffeescript, css, shell]
 type: [library, tool]
 stage: mature
-status: -STATUS-
+status: [active]
 ---
 
 The BubbleTree can be used to display hierarchical (spending) data in an interactive visualization. The setup is easy and independent from the OpenSpending platform. However, there is an optional integration module to connect with data from the OpenSpending API.

--- a/projects/_posts/1971-06-01-bubble-tree-library.html
+++ b/projects/_posts/1971-06-01-bubble-tree-library.html
@@ -12,6 +12,7 @@ slug: bubble-tree-library
 language: [javascript, coffeescript, css, shell]
 type: [library, tool]
 stage: mature
+status: -STATUS-
 ---
 
 The BubbleTree can be used to display hierarchical (spending) data in an interactive visualization. The setup is easy and independent from the OpenSpending platform. However, there is an optional integration module to connect with data from the OpenSpending API.

--- a/projects/_posts/1971-07-01-reclinejs.html
+++ b/projects/_posts/1971-07-01-reclinejs.html
@@ -16,7 +16,7 @@ helpwanted: yes
 language: [javascript, css]
 type: [library, tool]
 stage: mature
-status: -STATUS-
+status: [active]
 ---
 
 Recline is a simple but powerful library for building data applications in pure Javascript and HTML. Building on Backbone, Recline supplies components and structure to data-heavy applications by providing a set of models (Dataset, Record/Row, Field) and views (Grid, Map, Graph etc).

--- a/projects/_posts/1971-07-01-reclinejs.html
+++ b/projects/_posts/1971-07-01-reclinejs.html
@@ -16,6 +16,7 @@ helpwanted: yes
 language: [javascript, css]
 type: [library, tool]
 stage: mature
+status: -STATUS-
 ---
 
 Recline is a simple but powerful library for building data applications in pure Javascript and HTML. Building on Backbone, Recline supplies components and structure to data-heavy applications by providing a set of models (Dataset, Record/Row, Field) and views (Grid, Map, Graph etc).

--- a/projects/_posts/1971-08-01-data-okfn-org.md
+++ b/projects/_posts/1971-08-01-data-okfn-org.md
@@ -16,6 +16,7 @@ helpwanted: yes
 language: [javascript, css]
 type: [webapp, running service, tool]
 stage: live
+status: -STATUS-
 ---
 
 There's too much friction working with data - friction getting data, friction

--- a/projects/_posts/1971-08-01-data-okfn-org.md
+++ b/projects/_posts/1971-08-01-data-okfn-org.md
@@ -16,7 +16,7 @@ helpwanted: yes
 language: [javascript, css]
 type: [webapp, running service, tool]
 stage: live
-status: -STATUS-
+status: [active]
 ---
 
 There's too much friction working with data - friction getting data, friction

--- a/projects/_posts/1971-09-01-data-explorer.html
+++ b/projects/_posts/1971-09-01-data-explorer.html
@@ -14,6 +14,7 @@ helpwanted: yes
 language: [javascript, css]
 type: [webapp, running service, tool]
 stage: live
+status: -STATUS-
 ---
 
 Data Explorer is an in-browser data cleaning and visualization app. Load tabular data, process it with JavaScript, and graph the results, all in the comfort of your browser. Gist-based persistence enables simple versioning and sharing of projects.

--- a/projects/_posts/1971-09-01-data-explorer.html
+++ b/projects/_posts/1971-09-01-data-explorer.html
@@ -14,7 +14,7 @@ helpwanted: yes
 language: [javascript, css]
 type: [webapp, running service, tool]
 stage: live
-status: -STATUS-
+status: [active]
 ---
 
 Data Explorer is an in-browser data cleaning and visualization app. Load tabular data, process it with JavaScript, and graph the results, all in the comfort of your browser. Gist-based persistence enables simple versioning and sharing of projects.

--- a/projects/_posts/2013-09-01-elasticsearch-js.md
+++ b/projects/_posts/2013-09-01-elasticsearch-js.md
@@ -13,6 +13,7 @@ slug: elasticsearch-js
 language: [javascript]
 type: [library]
 stage: production
+status: -STATUS-
 ---
 
 <p>A simple javascript library for working with <a

--- a/projects/_posts/2013-09-01-elasticsearch-js.md
+++ b/projects/_posts/2013-09-01-elasticsearch-js.md
@@ -13,7 +13,7 @@ slug: elasticsearch-js
 language: [javascript]
 type: [library]
 stage: production
-status: -STATUS-
+status: [active]
 ---
 
 <p>A simple javascript library for working with <a

--- a/projects/_posts/2013-12-06-reconcile-csv.html
+++ b/projects/_posts/2013-12-06-reconcile-csv.html
@@ -13,7 +13,7 @@ slug: reconcile-csv
 language: [clojure]
 type: [webapp]
 stage: live
-status: -STATUS-
+status: [active]
 ---
 
 Reconcile-CSV is an OpenRefine reconciliation

--- a/projects/_posts/2013-12-06-reconcile-csv.html
+++ b/projects/_posts/2013-12-06-reconcile-csv.html
@@ -13,6 +13,7 @@ slug: reconcile-csv
 language: [clojure]
 type: [webapp]
 stage: live
+status: -STATUS-
 ---
 
 Reconcile-CSV is an OpenRefine reconciliation

--- a/projects/_posts/2014-01-10-data-pipes.html
+++ b/projects/_posts/2014-01-10-data-pipes.html
@@ -15,7 +15,7 @@ helpwanted: yes
 language: [javascript]
 type: [webapp, running service]
 stage: prototype
-status: -STATUS-
+status: [active]
 ---
 
 Data Pipes is a service to provide streaming, "pipe-like" data transformations on the web – things like deleting rows or columns, find and replace, head, grep etc.

--- a/projects/_posts/2014-01-10-data-pipes.html
+++ b/projects/_posts/2014-01-10-data-pipes.html
@@ -15,6 +15,7 @@ helpwanted: yes
 language: [javascript]
 type: [webapp, running service]
 stage: prototype
+status: -STATUS-
 ---
 
 Data Pipes is a service to provide streaming, "pipe-like" data transformations on the web – things like deleting rows or columns, find and replace, head, grep etc.

--- a/projects/_posts/2014-02-01-csv-js.md
+++ b/projects/_posts/2014-02-01-csv-js.md
@@ -14,6 +14,7 @@ helpwanted: no
 language: [javascript]
 type: [library]
 stage: production
+status: -STATUS-
 ---
 
 Simple javascript CSV library focused on the browser with **zero

--- a/projects/_posts/2014-02-01-csv-js.md
+++ b/projects/_posts/2014-02-01-csv-js.md
@@ -14,7 +14,7 @@ helpwanted: no
 language: [javascript]
 type: [library]
 stage: production
-status: -STATUS-
+status: [active]
 ---
 
 Simple javascript CSV library focused on the browser with **zero

--- a/projects/_posts/2014-05-20-ivo-of-chartres.md
+++ b/projects/_posts/2014-05-20-ivo-of-chartres.md
@@ -9,7 +9,7 @@ author: Bruce Brasington, Martin Brett, Przemyslaw Nowak, Christof Rolker
 featured: yes
 github_user: ivo-of-chartres
 github_repo: ivo-of-chartres.github.com
-status: -STATUS-
+status: [active]
 ---
 
 A collection of the works of Ivo, bishop of Chartres.

--- a/projects/_posts/2014-05-20-ivo-of-chartres.md
+++ b/projects/_posts/2014-05-20-ivo-of-chartres.md
@@ -9,6 +9,7 @@ author: Bruce Brasington, Martin Brett, Przemyslaw Nowak, Christof Rolker
 featured: yes
 github_user: ivo-of-chartres
 github_repo: ivo-of-chartres.github.com
+status: -STATUS-
 ---
 
 A collection of the works of Ivo, bishop of Chartres.

--- a/projects/_posts/2014-09-22-headstart.html
+++ b/projects/_posts/2014-09-22-headstart.html
@@ -15,6 +15,7 @@ helpwanted: yes
 language: [javascript, php]
 type: [visualization, webapp]
 stage: production
+status: -STATUS-
 ---
 
 Head Start is intended for scholars who want to get an overview of a research field. They could be young PhDs getting into a new field, or established scholars who venture into a neighboring field. The idea is that you can see the main areas and papers in a field at a glance without having to do weeks of searching and reading.

--- a/projects/_posts/2014-09-22-headstart.html
+++ b/projects/_posts/2014-09-22-headstart.html
@@ -15,7 +15,7 @@ helpwanted: yes
 language: [javascript, php]
 type: [visualization, webapp]
 stage: production
-status: -STATUS-
+status: [active]
 ---
 
 Head Start is intended for scholars who want to get an overview of a research field. They could be young PhDs getting into a new field, or established scholars who venture into a neighboring field. The idea is that you can see the main areas and papers in a field at a glance without having to do weeks of searching and reading.

--- a/projects/_posts/2014-11-05-open-knowledge-labs-website.md
+++ b/projects/_posts/2014-11-05-open-knowledge-labs-website.md
@@ -17,7 +17,7 @@ tags: []
 title: Open Knowledge Labs website
 type: [website]
 typeofhelp: [coding, blogging]
-status: -STATUS-
+status: [active]
 ---
 
 The Open Knowledge Labs website (i.e. the site you're looking at right now) is itself a collaborative project of Open Knowledge.  It is built using [Jekyll](http://jekyllrb.com), a static site generator, and hosted on GitHub Pages.  You can contribute by addressing some of the items on the project's GitHub [issue queue](https://github.com/okfn/okfn.github.com/issues) (hint: you can start with the [easy ones](https://github.com/okfn/okfn.github.com/labels/Easy)).

--- a/projects/_posts/2014-11-05-open-knowledge-labs-website.md
+++ b/projects/_posts/2014-11-05-open-knowledge-labs-website.md
@@ -17,6 +17,7 @@ tags: []
 title: Open Knowledge Labs website
 type: [website]
 typeofhelp: [coding, blogging]
+status: -STATUS-
 ---
 
 The Open Knowledge Labs website (i.e. the site you're looking at right now) is itself a collaborative project of Open Knowledge.  It is built using [Jekyll](http://jekyllrb.com), a static site generator, and hosted on GitHub Pages.  You can contribute by addressing some of the items on the project's GitHub [issue queue](https://github.com/okfn/okfn.github.com/issues) (hint: you can start with the [easy ones](https://github.com/okfn/okfn.github.com/labels/Easy)).

--- a/projects/_posts/2014-11-12-recline-mozilla-csv-viewer.html
+++ b/projects/_posts/2014-11-12-recline-mozilla-csv-viewer.html
@@ -13,7 +13,7 @@ slug: recline-mozilla-csv-viewer
 language: [javascript, css]
 type: [tool]
 stage: mature
-status: -STATUS-
+status: [active]
 ---
 
 A FireFox extension which allows you to view, search, graph and map CSV files in the browser (built using Recline).

--- a/projects/_posts/2014-11-12-recline-mozilla-csv-viewer.html
+++ b/projects/_posts/2014-11-12-recline-mozilla-csv-viewer.html
@@ -13,6 +13,7 @@ slug: recline-mozilla-csv-viewer
 language: [javascript, css]
 type: [tool]
 stage: mature
+status: -STATUS-
 ---
 
 A FireFox extension which allows you to view, search, graph and map CSV files in the browser (built using Recline).

--- a/projects/_posts/2014-11-13-dpm.html
+++ b/projects/_posts/2014-11-13-dpm.html
@@ -18,6 +18,7 @@ title: Data Package Manager
 type: [library, tool]
 helpwanted: yes
 typeofhelp: [coding, testing, documenting]
+status: -STATUS-
 ---
 
 <p>

--- a/projects/_posts/2014-11-13-dpm.html
+++ b/projects/_posts/2014-11-13-dpm.html
@@ -18,7 +18,7 @@ title: Data Package Manager
 type: [library, tool]
 helpwanted: yes
 typeofhelp: [coding, testing, documenting]
-status: -STATUS-
+status: [active]
 ---
 
 <p>

--- a/projects/_posts/2014-12-09-bad-data.md
+++ b/projects/_posts/2014-12-09-bad-data.md
@@ -17,6 +17,7 @@ title: Bad Data
 type: [running service]
 helpwanted: yes
 typeofhelp: [coding, testing, documenting]
+status: -STATUS-
 ---
 
 Bad Data is a site detailing real-world examples of how **not** to

--- a/projects/_posts/2014-12-09-bad-data.md
+++ b/projects/_posts/2014-12-09-bad-data.md
@@ -17,7 +17,7 @@ title: Bad Data
 type: [running service]
 helpwanted: yes
 typeofhelp: [coding, testing, documenting]
-status: -STATUS-
+status: [active]
 ---
 
 Bad Data is a site detailing real-world examples of how **not** to

--- a/projects/_posts/2015-01-08-bibjson.md
+++ b/projects/_posts/2015-01-08-bibjson.md
@@ -14,7 +14,7 @@ projecturl: http://okfnlabs.org/bibjson/
 stage: mature
 tags: [bibliographic metadata]
 tagline: Share and use bibliographic metadata online
-status: -STATUS-
+status: [active]
 ---
 
 BibJSON is a convention for representing bibliographic metadata in

--- a/projects/_posts/2015-01-08-bibjson.md
+++ b/projects/_posts/2015-01-08-bibjson.md
@@ -14,6 +14,7 @@ projecturl: http://okfnlabs.org/bibjson/
 stage: mature
 tags: [bibliographic metadata]
 tagline: Share and use bibliographic metadata online
+status: -STATUS-
 ---
 
 BibJSON is a convention for representing bibliographic metadata in

--- a/projects/_posts/2015-01-08-bibserver.md
+++ b/projects/_posts/2015-01-08-bibserver.md
@@ -16,7 +16,7 @@ projecturl: https://github.com/okfn/bibserver
 stage: mature
 tags: [bibliographic metadata]
 tagline: Publish, manage and find bibliographies simply and easily
-status: -STATUS-
+status: [active]
 ---
 
 BibServer is an open-source RESTful bibliographic data

--- a/projects/_posts/2015-01-08-bibserver.md
+++ b/projects/_posts/2015-01-08-bibserver.md
@@ -16,6 +16,7 @@ projecturl: https://github.com/okfn/bibserver
 stage: mature
 tags: [bibliographic metadata]
 tagline: Publish, manage and find bibliographies simply and easily
+status: -STATUS-
 ---
 
 BibServer is an open-source RESTful bibliographic data

--- a/projects/_posts/2015-01-08-facetview.md
+++ b/projects/_posts/2015-01-08-facetview.md
@@ -16,7 +16,7 @@ projecturl: http://okfnlabs.org/facetview/
 stage: mature
 tags: [elasticsearch]
 tagline: Pure JavaScript frontend for ElasticSearch
-status: -STATUS-
+status: [active]
 ---
 
 FacetView is a pure JavaScript frontend for

--- a/projects/_posts/2015-01-08-facetview.md
+++ b/projects/_posts/2015-01-08-facetview.md
@@ -16,6 +16,7 @@ projecturl: http://okfnlabs.org/facetview/
 stage: mature
 tags: [elasticsearch]
 tagline: Pure JavaScript frontend for ElasticSearch
+status: -STATUS-
 ---
 
 FacetView is a pure JavaScript frontend for

--- a/projects/_posts/2015-01-08-publicbodies.md
+++ b/projects/_posts/2015-01-08-publicbodies.md
@@ -17,6 +17,7 @@ projecturl: http://publicbodies.org/
 stage: mature
 tags: [node.js]
 tagline: A URL for every part of government
+status: -STATUS-
 ---
 
 PublicBodies.org is a website hosting a database of so-called *public

--- a/projects/_posts/2015-01-08-publicbodies.md
+++ b/projects/_posts/2015-01-08-publicbodies.md
@@ -17,7 +17,7 @@ projecturl: http://publicbodies.org/
 stage: mature
 tags: [node.js]
 tagline: A URL for every part of government
-status: -STATUS-
+status: [active]
 ---
 
 PublicBodies.org is a website hosting a database of so-called *public

--- a/projects/_posts/2015-01-08-webshot.md
+++ b/projects/_posts/2015-01-08-webshot.md
@@ -16,7 +16,7 @@ projecturl: http://webshot.okfnlabs.org/
 stage: mature
 tags: [node.js]
 tagline:  Free, automated generation of live screenshots of public websites
-status: -STATUS-
+status: [active]
 ---
 
 Webshot is a [Node.js](http://nodejs.org/)-based webservice provided

--- a/projects/_posts/2015-01-08-webshot.md
+++ b/projects/_posts/2015-01-08-webshot.md
@@ -16,6 +16,7 @@ projecturl: http://webshot.okfnlabs.org/
 stage: mature
 tags: [node.js]
 tagline:  Free, automated generation of live screenshots of public websites
+status: -STATUS-
 ---
 
 Webshot is a [Node.js](http://nodejs.org/)-based webservice provided

--- a/projects/_posts/2015-01-29-product-open-data.md
+++ b/projects/_posts/2015-01-29-product-open-data.md
@@ -16,7 +16,7 @@ imageurl: /img/projects/project-product-open-data.png
 language: [Java,Objective-C,Python,PHP,CSS]
 projecturl: http://product.okfn.org/
 stage:
-status:
+status: [active]
 tags:
 tagline: Building the world's largest public product database
 ---

--- a/projects/_posts/2015-02-23-dataportals-org.md
+++ b/projects/_posts/2015-02-23-dataportals-org.md
@@ -17,7 +17,7 @@ imageurl: /img/projects/project-dataportals.png
 stage: mature
 tags: [node.js]
 tagline: A catalog of data portals around the world
-status: -STATUS-
+status: [active]
 ---
 
 DataPortals.org is the most comprehensive list of open data portals in the world. It is curated by a group of leading open data experts from around the world - including representatives from local, regional and national governments, international organisations such as the World Bank, and numerous NGOs.

--- a/projects/_posts/2015-02-23-dataportals-org.md
+++ b/projects/_posts/2015-02-23-dataportals-org.md
@@ -17,6 +17,7 @@ imageurl: /img/projects/project-dataportals.png
 stage: mature
 tags: [node.js]
 tagline: A catalog of data portals around the world
+status: -STATUS-
 ---
 
 DataPortals.org is the most comprehensive list of open data portals in the world. It is curated by a group of leading open data experts from around the world - including representatives from local, regional and national governments, international organisations such as the World Bank, and numerous NGOs.

--- a/projects/_posts/2015-02-23-tika-server.md
+++ b/projects/_posts/2015-02-23-tika-server.md
@@ -16,6 +16,7 @@ projecturl: http://beta.offenedaten.de:9998/tika
 stage: alpha
 tags: [ocr]
 tagline: Turn many files, even text inside images, into text
+status: -STATUS-
 ---
 
 This is a web service available for converting a multitude of document types to simple text. It is a public facing instance of the Apache Tika server (developer version). It lives at:

--- a/projects/_posts/2015-02-23-tika-server.md
+++ b/projects/_posts/2015-02-23-tika-server.md
@@ -16,7 +16,7 @@ projecturl: http://beta.offenedaten.de:9998/tika
 stage: alpha
 tags: [ocr]
 tagline: Turn many files, even text inside images, into text
-status: -STATUS-
+status: [active]
 ---
 
 This is a web service available for converting a multitude of document types to simple text. It is a public facing instance of the Apache Tika server (developer version). It lives at:

--- a/projects/_posts/2015-03-08-goodtables.md
+++ b/projects/_posts/2015-03-08-goodtables.md
@@ -18,6 +18,7 @@ projecturl: http://goodtables.okfnlabs.org/
 stage: alpha
 tags: [Tabular Data, CSV, JSON Table Schema]
 tagline: Validate and process tabular data.
+status: -STATUS-
 ---
 
 The Good Tables web service provides an API and UI for processing and validating tabular data,

--- a/projects/_posts/2015-03-08-goodtables.md
+++ b/projects/_posts/2015-03-08-goodtables.md
@@ -18,7 +18,7 @@ projecturl: http://goodtables.okfnlabs.org/
 stage: alpha
 tags: [Tabular Data, CSV, JSON Table Schema]
 tagline: Validate and process tabular data.
-status: -STATUS-
+status: [active]
 ---
 
 The Good Tables web service provides an API and UI for processing and validating tabular data,

--- a/projects/_posts/2015-10-13-puppycidedb.md
+++ b/projects/_posts/2015-10-13-puppycidedb.md
@@ -18,6 +18,7 @@ projecturl: "https://puppycidedb.com"
 stage: production
 tags: [sql, Visualization]
 tagline: The Puppycide Database Project researches and records killings of animals by police across the United States with the help of open source applications & crowd sourced research.
+status: -STATUS-
 ---
 
  `Puppycide Database Project` is the largest public compilation of records related to killings of animals by police in the United States. The failure of US law enforcement to make records of lethal force available to the public has become a widely documented issue over the last few years. Despite the publicity, the issue remains unresolved at all levels of government - state, municipal and federal - leaving a small number of private, non-profit organizations to provide such basic information as human fatalities to researchers and journalists. The `Puppycide Database Project` is one such organization.

--- a/projects/_posts/2015-10-13-puppycidedb.md
+++ b/projects/_posts/2015-10-13-puppycidedb.md
@@ -18,7 +18,7 @@ projecturl: "https://puppycidedb.com"
 stage: production
 tags: [sql, Visualization]
 tagline: The Puppycide Database Project researches and records killings of animals by police across the United States with the help of open source applications & crowd sourced research.
-status: -STATUS-
+status: [active]
 ---
 
  `Puppycide Database Project` is the largest public compilation of records related to killings of animals by police in the United States. The failure of US law enforcement to make records of lethal force available to the public has become a widely documented issue over the last few years. Despite the publicity, the issue remains unresolved at all levels of government - state, municipal and federal - leaving a small number of private, non-profit organizations to provide such basic information as human fatalities to researchers and journalists. The `Puppycide Database Project` is one such organization.

--- a/projects/_posts/2015-11-21-mira.html
+++ b/projects/_posts/2015-11-21-mira.html
@@ -11,6 +11,7 @@ language: [Ruby]
 tags: [API, datapackage, csv, Ruby]
 tagline: create simple APIs from CSV files
 featured: yes
+status: -STATUS-
 ---
 
 This is a small application developed using Ruby-on-Rails. You upload a

--- a/projects/_posts/2015-11-21-mira.html
+++ b/projects/_posts/2015-11-21-mira.html
@@ -11,7 +11,7 @@ language: [Ruby]
 tags: [API, datapackage, csv, Ruby]
 tagline: create simple APIs from CSV files
 featured: yes
-status: -STATUS-
+status: [active]
 ---
 
 This is a small application developed using Ruby-on-Rails. You upload a


### PR DESCRIPTION
This relates to [issue 274](https://github.com/okfn/okfn.github.com/issues/274).

This adds a status attribute to those projects which didn't already have one set. In each case I set a default of "[active]". This is a start at least - we can modify each project's status attribute as appropriate (I'm not familiar with the majority of projects so did not want to set any to "[retired]" lest I offend someone :))

If I get a chance I'll use github's API to collate some data regarding each project's activity, which might give some clues to their statuses.

By the way, from the discussion in the issue thread (link above) do we want to agree on a fixed set of status values, e.g. active, retired, help wanted, maintainer wanted etc?