### PR TITLE
Updates to contacts page

### DIFF
--- a/_includes/list_signup.html
+++ b/_includes/list_signup.html
@@ -1,8 +1,0 @@
-<form action="https://sendy.okfn.org/subscribe"
-  method="POST" class="form">
-  <input type="text" class="input-medium" name="name" placeholder="Name" />
-  <input type="text" class="input-medium" name="email" placeholder="Email">
-  <br />
-  <input type="hidden" name="list" value="ldbyH0yjdqKptE8s10OrqA" />
-  <button type="submit" class="btn">Sign up</button>
-</form>

--- a/_layouts/two-column.html
+++ b/_layouts/two-column.html
@@ -11,10 +11,8 @@ layout: default
     <p>Join our discussion list. Here, we exchange
     datasets and ideas and plan our projects.</p>
 
-    {% include list_signup.html %}
-
-    <p>Many of us also hang out on IRC. Check out:</p>
-    <code>irc.freenode.org: #okfn</code>
+    <p>Many of us also hang out and chat on Gitter:</p>
+    <p><a href="https://gitter.im/okfn/chat">https://gitter.im/okfn/chat</a></p>
 
     <h3>Get Hacking</h3>
     <p>Check out the <a href="/projects">projects list</a> or

--- a/about/resources/index.md
+++ b/about/resources/index.md
@@ -76,7 +76,7 @@ be reviewed by an [Official Labs Contributor][Contributors].
 
 ### Messaging
 
-Mailing lists, IRC etc. See the [contact page][contact].
+Mailing lists, Twitter, chat etc. See the [contact page][contact].
 
 
 ## Coordination and Organizing

--- a/contact/index.html
+++ b/contact/index.html
@@ -7,17 +7,12 @@ bodyclass: contact
 <h1>Get in Touch with Us!</h1>
 <div class="row">
   <div class="span6">
-    <h2>Open Forum</h2>
+    <h2>Forum</h2>
     <p>Please ask general questions and share your feedback on <a href="/projects/">Labs projects</a> in our <a href="http://discuss.okfn.org/category/open-knowledge-labs">discussion forum</a>.</p>
 
 <!-- start feedwind code --><script type="text/javascript">document.write('<script type="text/javascript" src="' + ('https:' == document.location.protocol ? 'https://' : 'http://') + 'feed.mikle.com/js/rssmikle.js"><' + '/script>');</script><script type="text/javascript">(function() {var params = {rssmikle_url: "http://discuss.okfn.org/category/open-knowledge-labs.rss",rssmikle_frame_width: "300",rssmikle_frame_height: "300",rssmikle_target: "_blank",rssmikle_font: "Arial, Helvetica, sans-serif",rssmikle_font_size: "12",rssmikle_border: "off",responsive: "on",rssmikle_css_url: "",text_align: "left",text_align2: "left",corner: "off",scrollbar: "off",autoscroll: "on",scrolldirection: "down",scrollstep: "6",mcspeed: "30",sort: "New",rssmikle_title: "on",rssmikle_title_sentence: "",rssmikle_title_link: "",rssmikle_title_bgcolor: "#7ab800",rssmikle_title_color: "#FFFFFF",rssmikle_title_bgimage: "",rssmikle_item_bgcolor: "#FFFFFF",rssmikle_item_bgimage: "",rssmikle_item_title_length: "55",rssmikle_item_title_color: "#7AB800",rssmikle_item_border_bottom: "on",rssmikle_item_description: "on",item_link: "off",rssmikle_item_description_length: "150",rssmikle_item_description_color: "#666666",rssmikle_item_date: "gl1",rssmikle_timezone: "Etc/GMT",datetime_format: "%b %e, %Y %l:%M:%S %p",item_description_style: "text",item_thumbnail: "full",article_num: "15",rssmikle_item_podcast: "off",keyword_inc: "",keyword_exc: ""};feedwind_show_widget_iframe(params);})();</script><div style="font-size:10px; text-align:center; width:300;"><a href="http://feed.mikle.com/" target="_blank" style="color:#CCCCCC;">RSS Feed Widget</a><!--Please display the above link in your web page according to Terms of Service.--></div><!-- end feedwind code -->
 
-    <h2>Mailing Lists</h2>
-    <h3>Announce List and Newsletter</h3>
-    <p>This is our low traffic announce and newsletter list. Low traffic means ~2 emails a month or less.</p>
-    {% include list_signup.html %}
-
-    <h3>Discussion List</h3>
+    <h2>Discussion List</h2>
     <p>We have an open, public mailing list, <a href="http://lists.okfn.org/mailman/listinfo/okfn-labs">okfn-labs@lists.okfn.org</a>, for general discussion. Here, we talk about new tools and exchange ideas and plans for projects.</p>
     <form action="http://lists.okfn.org/mailman/subscribe/okfn-labs"
       method="POST" class="form">
@@ -28,18 +23,14 @@ bodyclass: contact
     </form>
   </div>
   <div class="span6">
-    <h2>IRC</h2>
-    <p>Many of us also hang out on IRC. Check out:</p>
-    <p><code>irc.freenode.org: #okfn</code></p>
-    <p>You can join directly <a href="http://webchat.freenode.net/?channels=okfn">via webchat</a></p>
+
+    <h2>Chat</h2>
+    <p>Many of us also hang out and chat on Gitter:</p>
+    <p><a href="https://gitter.im/okfn/chat">https://gitter.im/okfn/chat</a></p>
 
     <h2>Twitter</h2>
     <p>We have a twitter existence and we read @ replies</p>
     <p><a href="http://twitter.com/okfnlabs">http://twitter.com/okfnlabs</a></p>
-
-    <h2>Email</h2>
-    <p>If you'd like to in touch a bit more privately, or just prefer the old fashioned methods, you can reach the Labs coordinators at:</p>
-    <p><a href="mailto:labs@okfn.org">labs@okfn.org</a></p>
 
     <h2>GitHub</h2>
     <p>

--- a/index.html
+++ b/index.html
@@ -37,10 +37,6 @@ layout: default
     <p>
       There are also plenty of ways to <a href="/contact/">get in touch</a>.
     </p>
-    <h4>Get Updates</h4>
-    <p>Join our announce list and get regular (monthly) updates.</p>
-    {% include list_signup.html %}
-
     <h4>Twitter</h4>
     {% include tweets.html %}
 


### PR DESCRIPTION
Relates to issue [415](https://github.com/okfn/okfn.github.com/issues/415)

Removed email ref, replaced IRC info with Gitter info, removed signup to announce list, changed other site-wide references to IRC (now Gitter)