### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/blog/_posts/2012-10-22-messytables.md
+++ b/blog/_posts/2012-10-22-messytables.md
@@ -44,7 +44,7 @@ We've since also started using messytables to load data into the
 where it serves as the ETL for the datastore and related
 [ReclineJS](http://reclinejs.com/) previews.
 
-If you're interested, check out the [messytables documentation](http://messytables.readthedocs.org/en/latest/index.html)
+If you're interested, check out the [messytables documentation](https://messytables.readthedocs.io/en/latest/index.html)
 and the [uk25k scripts](https://github.com/openspending/dpkg-uk25k/blob/master/extract.py)
 which use it to gather UK government finance. 
 
@@ -54,7 +54,7 @@ data.
 * [tablib](http://docs.python-tablib.org/en/latest/), for example, has
 a fantastic API that makes writing, analyzing and converting data a
 breeze.
-* [csvkit](http://csvkit.readthedocs.org/en/latest/index.html) has a
+* [csvkit](https://csvkit.readthedocs.io/en/latest/index.html) has a
 set of command line utilities that should be pre-installed on any
 computer.
 

--- a/blog/_posts/2012-12-12-speeding-up-pybossa-apps.markdown
+++ b/blog/_posts/2012-12-12-speeding-up-pybossa-apps.markdown
@@ -24,7 +24,7 @@ The idea for reducing the loading time is actually pretty simple: We let the app
 
 <a rel="lightbox" title="Process flow in current PyBossa apps" href="/img/pybossa-workflow-new.png">![proposed workflow](/img/pybossa-workflow-new.png)</a>
 
-To implement this in PyBossa, we needed to change the PyBossa API a little bit (thanks @[teleyinex](https://github.com/PyBossa/pybossa/commit/4f5bdd4698a1ac21f3021347cd9ec08e68f18bdc)). Before that change consecutive calls to the [newtask endpoint](http://pybossa.readthedocs.org/en/latest/model.html#requesting-a-new-task-for-current-user) would return the same task again and again, until the user has solved it. Now with the newly introduced parameter **offset** you can request the next tasks in line.
+To implement this in PyBossa, we needed to change the PyBossa API a little bit (thanks @[teleyinex](https://github.com/PyBossa/pybossa/commit/4f5bdd4698a1ac21f3021347cd9ec08e68f18bdc)). Before that change consecutive calls to the [newtask endpoint](https://pybossa.readthedocs.io/en/latest/model.html#requesting-a-new-task-for-current-user) would return the same task again and again, until the user has solved it. Now with the newly introduced parameter **offset** you can request the next tasks in line.
 
 Another requirement for pre-loading of tasks is to keep the entire app on one page as otherwise the cached task would be lost. The rest of this post describes a smart way to implement this using [jQuery.Deferred](http://api.jquery.com/category/deferred-object/).
 

--- a/blog/_posts/2015-02-20-introducing-goodtables.md
+++ b/blog/_posts/2015-02-20-introducing-goodtables.md
@@ -21,7 +21,7 @@ The codebase currently ships with two validators that can be used in a pipeline:
 
 There is a hook to add custom processors, and there are plans to include more processorss in the core library.
 
-Good Tables ships with [some documentation](http://goodtables.readthedocs.org/en/latest/), but it is not yet complete. You are welcome to [check out the code](https://github.com/okfn/goodtables), [run the tests](https://github.com/okfn/goodtables/blob/master/test.sh) (or [check them on Travis](https://travis-ci.org/okfn/goodtables)), [open an issue](https://github.com/okfn/goodtables/issues), or make a pull request to help us iterate to a version one release ([here is the backlog](https://github.com/okfn/goodtables/milestones/Backlog)).
+Good Tables ships with [some documentation](https://goodtables.readthedocs.io/en/latest/), but it is not yet complete. You are welcome to [check out the code](https://github.com/okfn/goodtables), [run the tests](https://github.com/okfn/goodtables/blob/master/test.sh) (or [check them on Travis](https://travis-ci.org/okfn/goodtables)), [open an issue](https://github.com/okfn/goodtables/issues), or make a pull request to help us iterate to a version one release ([here is the backlog](https://github.com/okfn/goodtables/milestones/Backlog)).
 
 We are also released some packages that are used in Good Tables: [Good Tables Web](https://github.com/okfn/goodtables-web), [JTSKit](https://github.com/okfn/jtskit-py), and [TellMe](https://github.com/okfn/tellme). You can read more about each of these below.
 

--- a/blog/_posts/2015-03-06-goodtables-web-service.md
+++ b/blog/_posts/2015-03-06-goodtables-web-service.md
@@ -57,7 +57,7 @@ curl http://goodtables.okfnlabs.org/api/run --data "data=https://raw.githubuserc
 }
 </code></pre>
 
-For more details on the report response, see the <a href="http://goodtables.readthedocs.org/en/latest/reports.html">report section</a> of the <a href="http://goodtables.readthedocs.org/en/latest/index.html">Good Tables documentation</a>.
+For more details on the report response, see the <a href="https://goodtables.readthedocs.io/en/latest/reports.html">report section</a> of the <a href="https://goodtables.readthedocs.io/en/latest/index.html">Good Tables documentation</a>.
 
 ## UI
 

--- a/blog/_posts/2015-12-05-newsletter.md
+++ b/blog/_posts/2015-12-05-newsletter.md
@@ -36,7 +36,7 @@ A new Python library has begun to come of age. [Agate](https://github.com/onyxfi
 	
 > "In greater depth, agate is a Python data analysis library in the vein of numpy or pandas, but with one crucial difference. Whereas those libraries optimize for the needs of scientists—namely, being incredibly fast when working with vast numerical datasets—agate instead optimizes for the performance of the human who is using it. That means stripping out those technical optimizations and instead focusing on designing code that is easy to learn, readable, and flexible enough to handle any weird data you throw at it."
 	
-Agate's leap from version 0.11.0 to version 1.0.0 on October 22nd of this year marked the [first major release](https://agate.readthedocs.org/en/1.1.0/changelog.html) for the up-and-coming library (version 1.1 was released November 4th). While Agate was fully functional at v0.11.0, the changes since then have been substantial. Among some of the more impressive additions:
+Agate's leap from version 0.11.0 to version 1.0.0 on October 22nd of this year marked the [first major release](https://agate.readthedocs.io/en/1.1.0/changelog.html) for the up-and-coming library (version 1.1 was released November 4th). While Agate was fully functional at v0.11.0, the changes since then have been substantial. Among some of the more impressive additions:
 	
 - Agate can now be used as a drop-in replacement for Python’s csv module
 - Migrated csvkit‘s unicode CSV reading/writing support into agate
@@ -45,7 +45,7 @@ Agate's leap from version 0.11.0 to version 1.0.0 on October 22nd of this year m
 - Massive performance increases for joins.
 - Dozens of other resolved issues ...
 
-Agate has an impressive array of documentation for developers. Take a look at [the manual](https://agate.readthedocs.org/en/1.1.0/), the [standard tutorials](https://agate.readthedocs.org/en/1.1.0/tutorial.html), a tutorial for [using Agate with Jupyter notebook](http://nbviewer.ipython.org/urls/gist.githubusercontent.com/onyxfish/36f459dab02545cbdce3/raw/534698388e5c404996a7b570a7228283344adbb1/example.py.ipynb), the [Agate Cookbook](https://agate.readthedocs.org/en/1.1.0/cookbook.html) and the [Agate API documentation](https://agate.readthedocs.org/en/1.1.0/api.html).
+Agate has an impressive array of documentation for developers. Take a look at [the manual](https://agate.readthedocs.io/en/1.1.0/), the [standard tutorials](https://agate.readthedocs.io/en/1.1.0/tutorial.html), a tutorial for [using Agate with Jupyter notebook](http://nbviewer.ipython.org/urls/gist.githubusercontent.com/onyxfish/36f459dab02545cbdce3/raw/534698388e5c404996a7b570a7228283344adbb1/example.py.ipynb), the [Agate Cookbook](https://agate.readthedocs.io/en/1.1.0/cookbook.html) and the [Agate API documentation](https://agate.readthedocs.io/en/1.1.0/api.html).
 	
 Agate does indeed look promising, and there is an immense need for tools like it. Journalism is changing rapidly. With a flood of new information from Open Data advocates (like Open Knowledge) making their way to the newsroom, organizations that can effectively interpret that data will maintain a significant advantage over their competitors. Meanwhile, the public can only benefit from more accurate analysis of larger sets of information that impact their lives. Clearly, the need for analytics that were once only required at university now extends beyond the Ivory Tower.
 

--- a/events/zeitonline/index.html
+++ b/events/zeitonline/index.html
@@ -81,7 +81,7 @@ layout: events
           <li>insb: <a href="http://code.google.com/p/google-refine/wiki/GRELOtherFunctions">cross</a></li>
         </ul>
       </li>
-      <li><a href="http://shancarter.com/data_converter/">Mr Data Converter</a>, <a href="http://csvkit.readthedocs.org/en/latest/">csvkit</a></li>
+      <li><a href="http://shancarter.com/data_converter/">Mr Data Converter</a>, <a href="https://csvkit.readthedocs.io/en/latest/">csvkit</a></li>
       <li><a href="http://www.danielfett.de/internet-und-opensource,artikel,regulaere-ausdruecke">Reguläre Ausdrücke</a> ("RegEx", <a href="http://opencompany.org/download/regex-cheatsheet.pdf">Spickzettel</a>)</li>
     </ul>
   </div>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.