### PR TITLE
update example to use current version of tableschema-pandas-py

### DIFF
--- a/resources/using-data-packages-with-pandas.ipynb
+++ b/resources/using-data-packages-with-pandas.ipynb
@@ -14,33 +14,48 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import datapackage\n",
+    "from tableschema import Storage\n",
+    "from datapackage import Package\n",
     "import pandas as pd"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# load resources from a data package as Pandas data frames by using datapackage.push_datapackage function:\n",
-    "url = 'https://raw.githubusercontent.com/frictionlessdata/example-data-packages/master/cpi/datapackage.json'\n",
-    "storage = datapackage.push_datapackage(descriptor=url,backend='pandas')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['data__cpi___cpi']"
+       "True"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# load resources from a data package as Pandas data frames by using datapackage.push_datapackage function:\n",
+    "url = 'https://raw.githubusercontent.com/frictionlessdata/example-data-packages/master/cpi/datapackage.json'\n",
+    "\n",
+    "storage = Storage.connect('pandas')\n",
+    "package = Package(url)\n",
+    "package.save(storage=storage)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['cpi']"
+      ]
+     },
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -53,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -62,18 +77,18 @@
        "pandas.core.frame.DataFrame"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "type(storage['data__cpi___cpi'])"
+    "type(storage['cpi'])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -108,7 +123,7 @@
        "      <th>0</th>\n",
        "      <td>Afghanistan</td>\n",
        "      <td>AFG</td>\n",
-       "      <td>2002</td>\n",
+       "      <td>2004</td>\n",
        "      <td>63.131893</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -145,47 +160,47 @@
       ],
       "text/plain": [
        "  Country Name Country Code  Year         CPI\n",
-       "0  Afghanistan          AFG  2002   63.131893\n",
+       "0  Afghanistan          AFG  2004   63.131893\n",
        "1  Afghanistan          AFG  2005   71.140974\n",
        "2  Afghanistan          AFG  2006   76.302178\n",
        "3  Afghanistan          AFG  2007   82.774807\n",
        "4  Afghanistan          AFG  2008  108.066600"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# you can now use Pandas functions to work with your data package-turned-data frame\n",
-    "storage['data__cpi___cpi'].head()"
+    "storage['cpi'].head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "2002"
+       "2004"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# for example, let's look at the first value in the 'Year' column\n",
-    "storage['data__cpi___cpi']['Year'][0]"
+    "storage['cpi']['Year'][0]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -198,19 +213,19 @@
        "dtype: object"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# We can get the data types per column\n",
-    "storage['data__cpi___cpi'].dtypes"
+    "storage['cpi'].dtypes"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -219,19 +234,19 @@
        "Index(['Country Name', 'Country Code', 'Year', 'CPI'], dtype='object')"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# we can get the column names\n",
-    "storage['data__cpi___cpi'].columns"
+    "storage['cpi'].columns"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -336,7 +351,7 @@
        "      <th>0</th>\n",
        "      <td>Afghanistan</td>\n",
        "      <td>AFG</td>\n",
-       "      <td>2002</td>\n",
+       "      <td>2004</td>\n",
        "      <td>63.131893</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -356,34 +371,34 @@
        "3     Afghanistan          AFG  2007   82.774807\n",
        "2     Afghanistan          AFG  2006   76.302178\n",
        "1     Afghanistan          AFG  2005   71.140974\n",
-       "0     Afghanistan          AFG  2002   63.131893\n",
+       "0     Afghanistan          AFG  2004   63.131893\n",
        "\n",
        "[6936 rows x 4 columns]"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# we can sort the data\n",
-    "storage['data__cpi___cpi'].sort_index(axis=0, ascending=False)"
+    "storage['cpi'].sort_index(axis=0, ascending=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
     "# we can set new values\n",
-    "storage['data__cpi___cpi'].at[0,'Year'] = 2002"
+    "storage['cpi'].at[0,'Year'] = 2002"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -513,50 +528,43 @@
        "[6936 rows x 4 columns]"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# viewing the dataframe\n",
-    "storage['data__cpi___cpi']"
+    "\n",
+    "storage['cpi']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
     "# now let's pull this data frame back into a data package:\n",
-    "from datapackage import Package"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "\n",
     "# note, you can use a local file instead of a URL here\n",
     "packageURL = 'https://raw.githubusercontent.com/frictionlessdata/examples/master/cpi/datapackage.json'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
-    "newDatapackage = datapackage.Package(packageURL, 'country_list', 'pandas', tables={\n",
-    "...     'data': storage['data__cpi___cpi'],\n",
+    "newDatapackage = Package(packageURL, 'country_list', 'pandas', tables={\n",
+    "...     'data': storage['cpi'],\n",
     "... })"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -577,7 +585,7 @@
        "   'missingValues': ['']}}]"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -603,9 +611,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
The way the Pandas notebook was structured, by using `datapackage.push_datapackage` has been deprecated and no longer works with current versions. See [tableschema-pandas-py#33](https://github.com/frictionlessdata/tableschema-pandas-py/issues/33).

This PR updates the notebook to reflect the current way of using the library, just as in the recently updated [example in the README](https://github.com/frictionlessdata/tableschema-pandas-py/blob/master/README.md#example).